### PR TITLE
github: Auto-tag every merge to master

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,40 @@
+name: bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      id: bump_version
+      uses: anothrNick/github-tag-action@1.30.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch
+    # Create a release for frontpage visibility and downloading the tar
+    - name: Get commit message
+      run: git log --format=%B -n 1 HEAD > /tmp/commit-msg
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.bump_version.outputs.tag }}
+        release_name: Release ${{ steps.bump_version.outputs.tag }}
+        body_path: /tmp/commit-msg
+    # Get the latest module version so pkg.go.dev updates
+    - uses: actions/setup-go@v2.1.2
+      with:
+        go-version: 1.14
+    - name: Update pkg.go.dev
+      env:
+        GO111MODULE: on
+      working-directory: /tmp
+      run: go get foxygo.at/foxtrot@${{ steps.bump_version.outputs.tag }}


### PR DESCRIPTION
Auto-tag every merge to master with a patch version bump unless
specified differently in commit message (see action docs [1]). This
action is a copy of foxygoat/s version action, except for the last
line referencing the repo's go module[2].

[1] https://github.com/anothrNick/github-tag-action
[2] https://github.com/foxygoat/s/blob/71cbe2e7b1a32c52172b91a3c5a6f54991f8e6ea/.github/workflows/version.yaml