### PR TITLE
build: Add Dockerfile and make target to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.15.5-alpine3.12 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum Makefile ./
+COPY pkg pkg/
+COPY cmd cmd/
+RUN apk add make
+RUN make install
+
+FROM alpine:3.12.1
+WORKDIR /app
+COPY --from=builder /go/bin/foxtrot .
+COPY static static/
+CMD /app/foxtrot

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ lint-with-docker:  ## Lint source code with docker image of golangci-lint
 
 .PHONY: lint lint-with-local lint-with-docker
 
+# --- Docker -------------------------------------------------------------------
+
+docker-build:
+	docker build --tag foxtrot:latest .
+
 # --- Utilities ----------------------------------------------------------------
 COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
 COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)


### PR DESCRIPTION
Add a Dockerfile to build a foxtrot container image, based on an alpine
image, and add a target to the makefile to build that image.