### PR TITLE
github: Update setup-go action version

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -30,7 +30,7 @@ jobs:
         release_name: Release ${{ steps.bump_version.outputs.tag }}
         body_path: /tmp/commit-msg
     # Get the latest module version so pkg.go.dev updates
-    - uses: actions/setup-go@v2.1.2
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.14
     - name: Update pkg.go.dev


### PR DESCRIPTION
Update setup-go action version from 2.1.2 to 2, in hope to fix a new error on CI:

    Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.15.4/x64' successfully.
    Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This has already been fixed in 4a4e345337c43a1d0a30bc40485abe80e79582e6
for ci.yaml, but the version.yaml workflow triggered on merge to master
has been overlooked.