### PR TITLE
ci: Use golangci lint action instead of building it

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,7 +18,16 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.2
+    # Install golangci-lint, but run with --version so it does not run.
+    # We run lint from the Makefile. Use @master because we want the
+    # skip-go-installation option which has not yet been released.
+    # TODO(camh): Change master to v2 when v2.4.0 is released.
+    - name: Install golangci-lint
+      uses: golangci/golangci-lint-action@master
+      with:
+        version: v1.33.2
+        skip-go-installation: true
+        args: --version
     - run: make
     - run: make docker-test
 


### PR DESCRIPTION
Use the official golangci lint github action instead of building it
ourselves. We could not do this before because it would install a
version of Go different to what we were using. This has been fixed to
not install Go if it already is.