### PR TITLE
api: Add version endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ jobs:
         stable: false
         go-version: 1.16.0-beta1
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     # Install golangci-lint, but run with --version so it does not run.
     # We run it from the Makefile ourselves. It is installed so it does
     # not depend on the version of Go in the docker image, which the

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,4 +46,6 @@ jobs:
     - uses: crazy-max/ghaction-docker-buildx@v3
     - run: make docker-build-release
       env:
+        SEMVER: ${{ steps.bump_version.outputs.tag }}
+        COMMIT_SHA: ${GITHUB_SHA}
         DOCKER_TAG: ${{ steps.bump_version.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM golang:1.16beta1-buster AS builder
 
+ARG COMMIT_SHA
+ARG SEMVER
+ENV COMMIT_SHA=${COMMIT_SHA}
+ENV SEMVER=${SEMVER}
+
 WORKDIR /src
 COPY go.mod go.sum Makefile ./
 COPY pkg pkg/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ data store or define the authenticator secret.
 Access the foxtrot API server locally with
 
     curl 'localhost:8080/api/history?room=$Kitchen'
+    curl localhost:8080/api/version
 
 ### DB
 

--- a/cmd/foxtrot/main.go
+++ b/cmd/foxtrot/main.go
@@ -10,8 +10,17 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+var (
+	// Semver holds the version exposed at api/version and passed via linker flag on CI.
+	Semver = "undefined"
+	// CommitSha holds the commit exposed at api/version and passed via linker flag on CI.
+	CommitSha = "undefined"
+)
+
 func main() {
-	cfg := &foxtrot.Config{}
+	cfg := &foxtrot.Config{
+		Version: foxtrot.Version{Semver: Semver, CommitSha: CommitSha},
+	}
 	kong.Parse(cfg, kong.Description("Foxtrot Server"))
 
 	mux := http.NewServeMux()

--- a/pkg/foxtrot/api.go
+++ b/pkg/foxtrot/api.go
@@ -24,12 +24,14 @@ import (
 type api struct {
 	db   *db
 	auth *authenticator
+	ver  Version
 }
 
-func newAPI(db *db, auth *authenticator) *api {
+func newAPI(db *db, auth *authenticator, version Version) *api {
 	a := &api{
 		db:   db,
 		auth: auth,
+		ver:  version,
 	}
 	return a
 }
@@ -38,6 +40,7 @@ func (a *api) wireRoutes(basePath string, mux *http.ServeMux) {
 	mux.Handle(basePath+"/login", httpe.Must(httpe.Post, a.login))
 	mux.Handle(basePath+"/register", httpe.Must(httpe.Post, a.register))
 	mux.Handle(basePath+"/history", httpe.Must(httpe.Get, a.history))
+	mux.Handle(basePath+"/version", httpe.Must(httpe.Get, a.version))
 	mux.Handle(basePath+"/_test_cleanup", httpe.Must(httpe.Delete, a.testCleanup))
 }
 
@@ -93,6 +96,10 @@ func (a *api) history(w http.ResponseWriter, r *http.Request) error {
 		return httpe.ErrInternalServerError
 	}
 	return json.NewEncoder(w).Encode(messages)
+}
+
+func (a *api) version(w http.ResponseWriter, r *http.Request) error {
+	return json.NewEncoder(w).Encode(a.ver)
 }
 
 const testUser = "$user"

--- a/pkg/foxtrot/foxtrot.go
+++ b/pkg/foxtrot/foxtrot.go
@@ -13,6 +13,15 @@ import (
 type Config struct {
 	DSN        string `help:"SQLite Data Source Name" default:":memory:"`
 	AuthSecret string `help:"JWT token generation secret. default: <RANDOM_STRING>" env:"FT_AUTH_SECRET"`
+
+	Version Version `kong:"-"`
+}
+
+// Version contains build version information which is returned as JSON
+// at the version HTTP endpoint.
+type Version struct {
+	CommitSha string `json:"commitSha"`
+	Semver    string `json:"semver"`
 }
 
 // NewApp creates a new App struct for given config and wire it with
@@ -31,7 +40,7 @@ func NewApp(cfg *Config, mux *http.ServeMux) (*App, error) {
 		}
 	}
 	auth := &authenticator{db: db, secret: secret}
-	api := newAPI(db, auth)
+	api := newAPI(db, auth, cfg.Version)
 	api.wireRoutes("/api", mux)
 	app := &App{db: db, auth: auth, api: api}
 	return app, nil


### PR DESCRIPTION
Add version endpoint returning commit SHA and semver of current build at

	/api/version

Wire it with CI, Docker and tests.