### PR TITLE
deploy: Add k8s deployment

### DIFF
--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -1,0 +1,116 @@
+{
+  config:: {
+    hostname: null,
+    docker_tag: 'latest',
+  },
+  configure(hostname=null, docker_tag=null)::
+    self {
+      config+: std.prune({
+        hostname: hostname,
+        docker_tag: docker_tag,
+      }),
+    },
+
+  manifest: [
+    $.namespace,
+    $.service,
+    $.deployment,
+    if $.config.hostname != null then $.ingress,
+  ],
+  namespace:: {
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: {
+      name: 'foxtrot',
+    },
+  },
+  service:: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: 'foxtrot',
+      namespace: 'foxtrot',
+    },
+    spec: {
+      ports: [{ name: 'http', port: 8080 }],
+      selector: {
+        app: 'foxtrot',
+      },
+    },
+  },
+  deployment:: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      labels: {
+        app: 'foxtrot',
+      },
+      name: 'foxtrot',
+      namespace: 'foxtrot',
+    },
+    spec: {
+      selector: {
+        matchLabels: {
+          app: 'foxtrot',
+        },
+      },
+      template: {
+        metadata: {
+          labels: {
+            app: 'foxtrot',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              image: 'foxygoat/foxtrot:%s' % $.config.docker_tag,
+              name: 'foxtrot',
+              ports: [{ containerPort: 8080, name: 'http', protocol: 'TCP' }],
+            },
+          ],
+        },
+      },
+    },
+  },
+  ingress:: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'Ingress',
+    metadata: {
+      annotations: {
+        'cert-manager.io/cluster-issuer': 'letsencrypt',
+        'traefik.ingress.kubernetes.io/router.entrypoints': 'https',
+      },
+      name: 'foxtrot',
+      namespace: 'foxtrot',
+    },
+    spec: {
+      rules: [
+        {
+          host: $.config.hostname,
+          http: {
+            paths: [
+              {
+                backend: {
+                  service: {
+                    name: 'foxtrot',
+                    port: {
+                      name: 'http',
+                    },
+                  },
+                },
+                path: '/',
+                pathType: 'Prefix',
+              },
+            ],
+          },
+        },
+      ],
+      tls: [
+        {
+          hosts: [$.config.hostname],
+          secretName: 'foxtrot-https-cert',
+        },
+      ],
+    },
+  },
+}

--- a/deployment/main.jsonnet
+++ b/deployment/main.jsonnet
@@ -1,0 +1,1 @@
+(import 'foxtrot.jsonnet').configure


### PR DESCRIPTION
Add k8s jsonnet deployment, parameterised on hostname and docker tag.

Usage:

    kubecfg update -A hostname=foxtrot.example.com -A docker_tag=v0.0.1 main.jsonnet

Note: If hostname is set an ingress resource is created for which it
assumes that Let's encrypt is set up on the cluster and that there is a
Traefik entry point called https.

If no docker tag is provided, the default `latest` is used.

Example deployment with k3s setup [1]:

    export KUBECONFIG=/opt/k3s/etc/kubeconfig.yaml
    kubecfg update -A hostname=foxtrot.example.com main.jsonnet

Use TLAs to configure the manifests instead of extVars, so we can have
default values that can be optionally overridden.

[1]: https://github.com/foxygoat/k3sinst