### PR TITLE
github: Update docker buildx action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -82,8 +82,10 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Set up docker buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
+    - name: Set up QEMU (crossplatform Docker images)
+      uses: docker/setup-qemu-action@v1
+    - name: Set up docker buildx (crossplatform Docker images)
+      uses: docker/setup-buildx-action@v1
     - run: make docker-build-release
       env:
         COMMIT_SHA: ${GITHUB_SHA}


### PR DESCRIPTION
Update docker buildx action from crazy-max/ghaction-docker-buildx@v3 to
docker/setup-buildx-action@v1, as the later is the now officially
supported on.

This update also required a separate QEMU (platform emulator) setup
step that previously was integrated in the buildx action.