### PR TITLE
deploy: Create goat CD with JCDC

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -91,3 +91,10 @@ jobs:
         COMMIT_SHA: ${GITHUB_SHA}
         DOCKER_TAG: ${{ steps.make_tag.outputs.docker_tag }}
         DOCKER_PUSH_LATEST: ${{ github.event_name == 'push' }}
+    - run: make jcdc-deploy-goat
+      if: github.event_name == 'push'
+      env:
+        REF: ${{ github.sha }}
+        JCDC_URL: https://jcdc.jul.run/run
+        JCDC_API_KEY: ${{ secrets.GOAT_JCDC_API_KEY }}
+        DOCKER_TAG: ${{ steps.make_tag.outputs.docker_tag }}

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,42 @@ docker-test: docker-build
 
 .PHONY: docker-build docker-build-release docker-run docker-test
 
+# --- Deployment -------------------------------------------------------------------
+TLA_ARGS = \
+	--tla-str docker_tag=$(DOCKER_TAG) \
+	--tla-code-file overlay=deployment/$*/overlay.jsonnet \
+	$(if $(DEPLOY_HOSTNAME), --tla-str hostname=$(DEPLOY_HOSTNAME))
+
+deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  ## Generate and deploy k8s manifests
+	kubecfg update $(TLA_ARGS) deployment/main.jsonnet
+
+show-deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  ## Show k8s manifests that would be deployed
+	kubecfg show $(TLA_ARGS) deployment/main.jsonnet
+
+diff-deploy-%: ## Show diff of k8s manifests between files and deployed
+	kubecfg diff $(TLA_ARGS) deployment/main.jsonnet
+
+undeploy-%:  ## Delete deployment
+	kubecfg delete $(TLA_ARGS) deployment/main.jsonnet
+
+deployment/%:
+	mkdir $@
+
+deployment/%/secret.json:
+	kubectl create secret generic foxtrot -n foxtrot --from-literal=authsecret=$$(openssl rand -hex 32) --dry-run=client -o yaml | kubeseal -w $@
+
+deployment/%/overlay.jsonnet:
+	@printf '{ manifest+: [$$.sealedSecret], \n config+: { hostname: null // add your hostname \n }, \n sealedSecret:: import "secret.json"}' | jsonnetfmt -o $@ -
+	@printf '\ndefault overlay generated: %s \n' $@
+	@printf 'review and run `make deploy-$*` again.\n\n'
+	@exit 1
+
+show-secret:  ## Show currently deployed foxtrot auth secret
+	kubectl get secret -n foxtrot foxtrot -o go-template='{{.data.authsecret | base64decode}}{{"\n"}}'
+
+.PRECIOUS: deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet
+.PHONY: show-secret
+
 # --- Utilities ----------------------------------------------------------------
 COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
 COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)
 COLOUR_WHITE  = $(shell tput setaf 7 2>/dev/null)
 
 help:
-	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9%_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 $(O):
 	@mkdir -p $@

--- a/cmd/foxtrot/main.go
+++ b/cmd/foxtrot/main.go
@@ -19,7 +19,7 @@ var (
 
 func main() {
 	cfg := &foxtrot.Config{
-		Version: foxtrot.Version{Semver: Semver, CommitSha: CommitSha},
+		Version: foxtrot.Version{Semver: Semver, CommitSha: CommitSha, App: "foxtrot"},
 	}
 	kong.Parse(cfg, kong.Description("Foxtrot Server"))
 

--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -3,8 +3,8 @@
     hostname: null,
     docker_tag: 'latest',
   },
-  configure(hostname=null, docker_tag=null)::
-    self {
+  configure(overlay={}, hostname=null, docker_tag=null)::
+    self + overlay + {
       config+: std.prune({
         hostname: hostname,
         docker_tag: docker_tag,
@@ -66,6 +66,10 @@
               image: 'foxygoat/foxtrot:%s' % $.config.docker_tag,
               name: 'foxtrot',
               ports: [{ containerPort: 8080, name: 'http', protocol: 'TCP' }],
+              env: [{
+                name: 'FT_AUTH_SECRET',
+                valueFrom: { secretKeyRef: { key: 'authsecret', name: 'foxtrot' } },
+              }],
             },
           ],
         },

--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -63,7 +63,9 @@
         spec: {
           containers: [
             {
+              local policy(tag) = if tag == 'latest' || std.startsWith(tag, 'pr') then 'Always' else 'IfNotPresent',
               image: 'foxygoat/foxtrot:%s' % $.config.docker_tag,
+              imagePullPolicy: policy($.config.docker_tag),
               name: 'foxtrot',
               ports: [{ containerPort: 8080, name: 'http', protocol: 'TCP' }],
               env: [{

--- a/deployment/goat/overlay.jsonnet
+++ b/deployment/goat/overlay.jsonnet
@@ -1,0 +1,7 @@
+{
+  manifest+: [$.sealedSecret],
+  config+: {
+    hostname: 'foxtrot.jul.run',
+  },
+  sealedSecret:: import 'secret.json',
+}

--- a/deployment/goat/secret.json
+++ b/deployment/goat/secret.json
@@ -1,0 +1,21 @@
+{
+  "kind": "SealedSecret",
+  "apiVersion": "bitnami.com/v1alpha1",
+  "metadata": {
+    "name": "foxtrot",
+    "namespace": "foxtrot",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "template": {
+      "metadata": {
+        "name": "foxtrot",
+        "namespace": "foxtrot",
+        "creationTimestamp": null
+      }
+    },
+    "encryptedData": {
+      "authsecret": "AgA0GPO+QwQuHK0t55q7W6SM+jMQWU5Ic8ozLnfvXrdOQIhN8l/TeFbiB+pLgYY38874lJyxhPWxa0tD5wcMiwDHJzYYiMwcQBhgZvmveAjDBkfx3RhlkEXB7UAtVB3JDWHDTO8Fgl3DNYX1Ly0vHxZEyJGp94O1cPuQat3RJblybtVg+KvAn7YhPEWR9ECtEt9BqUzLJFXOwrXqXk50eI157d20ooqxcGvrZBgop35Z52lu76NnHUym2ZjxZA7+rX+g3q0jzuAOLlT/plZanFpfYGWFTqqdfssuauddIxJeEv8PGFFPjS533xwq+mEnqFmFZP8wjDqnApgGhFeTCD5D3e22fEXsofx3Wj5H6NUGV8sCEO8mSgena82ys4iznotJgg6pYpnBS3goiItXRLoF7z/hvDqXgkjTqU5duLUh3/I6B/UCJoYJL5kRLuFKYx/GStUPz5pzV/vlfwsr0ESe7mWLlW6ZZVLjANZDeNd3kXhSGavgdf+ngMR1UdtDjyL6zo7A9mCczgnzG9/zqcnlpezPuYKq/4XkTiYUMtCoeKFzPzPgTS5TVgPWkqrqspADb29DKZLT6Dq1UaF7E6jFR2YCNkaIFpXALYV1GFZUsBJPjQMIluY3e+BtdKVr4PkAa4ho7chuvSewDOBBgTwXmLgTrE9qyBoplmlLAj7Pa+8KzSAaBxUs146mAtFDLc5burYG+Z8yQeQZ0wAYre8FH6WnWuU0A79rPyq7YmQ7ICwVXU/6ln51j/vApS+5EBXoviLv7zcWCHlkaj81Se1N"
+    }
+  }
+}

--- a/pkg/foxtrot/api_test.go
+++ b/pkg/foxtrot/api_test.go
@@ -27,6 +27,7 @@ type APITestSuite struct {
 const (
 	testSemver    = "v0.0.0-test"
 	testCommitSha = "123456789abcdef"
+	testApp       = "testFoxtrot"
 )
 
 func (s *APITestSuite) SetupSuite() {
@@ -35,8 +36,12 @@ func (s *APITestSuite) SetupSuite() {
 	if s.baseURL == "" {
 		mux := http.NewServeMux()
 		cfg := &Config{
-			DSN:     ":memory:",
-			Version: Version{Semver: testSemver, CommitSha: testCommitSha},
+			DSN: ":memory:",
+			Version: Version{
+				App:       testApp,
+				CommitSha: testCommitSha,
+				Semver:    testSemver,
+			},
 		}
 		_, err := NewApp(cfg, mux)
 		require.NoError(t, err)
@@ -150,11 +155,13 @@ func (s *APITestSuite) TestVersion() {
 	require.NoError(t, err, body)
 	require.NotEmpty(t, version.Semver)
 	require.NotEmpty(t, version.CommitSha)
+	require.NotEmpty(t, version.App)
 	require.NotEqual(t, "undefined", version.CommitSha)
 	require.NotEqual(t, "undefined", version.Semver)
 	if s.server != nil {
 		require.Equal(t, testCommitSha, version.CommitSha)
 		require.Equal(t, testSemver, version.Semver)
+		require.Equal(t, testApp, version.App)
 	}
 }
 

--- a/pkg/foxtrot/foxtrot.go
+++ b/pkg/foxtrot/foxtrot.go
@@ -20,6 +20,7 @@ type Config struct {
 // Version contains build version information which is returned as JSON
 // at the version HTTP endpoint.
 type Version struct {
+	App       string `json:"app"`
 	CommitSha string `json:"commitSha"`
 	Semver    string `json:"semver"`
 }


### PR DESCRIPTION
Provide continuous deployment via jcdc[1] for new merges to master.
Update deployment, Makefile and GitHub action accordingly.

Update and fix sundry:

- Add app field to version info in go source
- Fix help messages in Makefile
- Create auth secret in deployment
- Create deployment overlay setup with jsonnet for specific deployment (goat)
- Add auxiliary make targets `diff-deploy` and `undeploy-%`
- Fix deployment image pull policy for images with label starting with `pr`

[1]: https://jcdc.jul.run/version