### PR TITLE
Add optional per PR deployment

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -91,10 +91,15 @@ jobs:
         COMMIT_SHA: ${GITHUB_SHA}
         DOCKER_TAG: ${{ steps.make_tag.outputs.docker_tag }}
         DOCKER_PUSH_LATEST: ${{ github.event_name == 'push' }}
+    - name: Make dev label
+      if: github.event_name == 'pull_request'
+      id: make_dev_label
+      run: echo ::set-output name=dev_label::pr${{ github.event.number }}
+      shell: bash
     - run: make jcdc-deploy-goat
-      if: github.event_name == 'push'
       env:
         REF: ${{ github.sha }}
+        DEV: ${{ steps.make_dev_label.outputs.dev_label }}
         JCDC_URL: https://jcdc.jul.run/run
         JCDC_API_KEY: ${{ secrets.GOAT_JCDC_API_KEY }}
         DOCKER_TAG: ${{ steps.make_tag.outputs.docker_tag }}

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ REMOTE_OVERLAY = https://github.com/foxygoat/foxtrot/raw/$(REF)/$(LOCAL_OVERLAY)
 OVERLAY = $(LOCAL_OVERLAY)
 TLA_ARGS = \
 	--tla-str docker_tag=$(DOCKER_TAG) \
+	$(if $(DEV), --tla-str dev=$(DEV)) \
 	--tla-code-file overlay=$(OVERLAY)
 
 deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.jsonnet  ## Generate and deploy k8s manifests

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ show-deploy-%: | deployment/% deployment/%/secret.json deployment/%/overlay.json
 	kubecfg show $(TLA_ARGS) deployment/main.jsonnet
 
 diff-deploy-%: ## Show diff of k8s manifests between files and deployed
-	kubecfg diff $(TLA_ARGS) deployment/main.jsonnet
+	kubecfg diff --diff-strategy subset $(TLA_ARGS) deployment/main.jsonnet
 
 undeploy-%:  ## Delete deployment
 	kubecfg delete $(TLA_ARGS) deployment/main.jsonnet


### PR DESCRIPTION
Deploy PRs labelled with `deploy` using `make jcdc-deploy-goat` as part
of GitHub Workflow CI/CD.

Optional per-PR deployment is implemented to more easily preview
frontend changes.

Update kubecfg diff strategy and refactor `jcdc-*` targets as stepping stone for per PR deployment clenups.