### PR TITLE
deploy: Annotate deployment with commit sha

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -88,7 +88,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - run: make docker-build-release
       env:
-        COMMIT_SHA: ${GITHUB_SHA}
+        COMMIT_SHA: ${{ github.sha }}
         DOCKER_TAG: ${{ steps.make_tag.outputs.docker_tag }}
         DOCKER_PUSH_LATEST: ${{ github.event_name == 'push' }}
     - name: Make dev label
@@ -98,7 +98,7 @@ jobs:
       shell: bash
     - run: make jcdc-deploy-goat
       env:
-        REF: ${{ github.sha }}
+        COMMIT_SHA: ${{ github.sha }}
         DEV: ${{ steps.make_dev_label.outputs.dev_label }}
         JCDC_URL: https://jcdc.jul.run/run
         JCDC_API_KEY: ${{ secrets.GOAT_JCDC_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ REMOTE_OVERLAY = https://github.com/foxygoat/foxtrot/raw/$(COMMIT_SHA)/$(LOCAL_O
 OVERLAY = $(LOCAL_OVERLAY)
 TLA_ARGS = \
 	--tla-str docker_tag=$(DOCKER_TAG) \
+	--tla-str commit_sha=$(COMMIT_SHA) \
 	$(if $(DEV), --tla-str dev=$(DEV)) \
 	--tla-code-file overlay=$(OVERLAY)
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ docker-test: docker-build
 
 # --- Deployment -------------------------------------------------------------------
 LOCAL_OVERLAY = deployment/$*/overlay.jsonnet
-REMOTE_OVERLAY = https://github.com/foxygoat/foxtrot/raw/$(REF)/$(LOCAL_OVERLAY)
+REMOTE_OVERLAY = https://github.com/foxygoat/foxtrot/raw/$(COMMIT_SHA)/$(LOCAL_OVERLAY)
 OVERLAY = $(LOCAL_OVERLAY)
 TLA_ARGS = \
 	--tla-str docker_tag=$(DOCKER_TAG) \
@@ -143,7 +143,7 @@ show-secret:  ## Show currently deployed foxtrot auth secret
 CURL_FLAGS = --silent --show-error --retry 3 --dump-header -
 JCDC_DEPLOY_PAYLOAD = \
 { \
-	"command": "kubecfg update $(TLA_ARGS) https://github.com/foxygoat/foxtrot/raw/$(REF)/deployment/main.jsonnet", \
+	"command": "kubecfg update $(TLA_ARGS) https://github.com/foxygoat/foxtrot/raw/$(COMMIT_SHA)/deployment/main.jsonnet", \
 	"apiKey": "$(JCDC_API_KEY)" \
 }
 jcdc-deploy-%: OVERLAY = $(REMOTE_OVERLAY)
@@ -152,7 +152,7 @@ jcdc-deploy-%:
 
 JCDC_UNDEPLOY_PAYLOAD = \
 { \
-	"command": "kubecfg delete $(TLA_ARGS) https://github.com/foxygoat/foxtrot/raw/$(REF)/deployment/main.jsonnet", \
+	"command": "kubecfg delete $(TLA_ARGS) https://github.com/foxygoat/foxtrot/raw/$(COMMIT_SHA)/deployment/main.jsonnet", \
 	"apiKey": "$(JCDC_API_KEY)" \
 }
 jcdc-undeploy-%: OVERLAY = $(REMOTE_OVERLAY)

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ diff-deploy-%: ## Show diff of k8s manifests between files and deployed
 undeploy-%:  ## Delete deployment
 	kubecfg delete $(TLA_ARGS) deployment/main.jsonnet
 
+dev-undeploy-%:  ## Delete dev deployment
+	kubectl delete all -n foxtrot -l app=foxtrot,dev=$(DEV)
+	kubectl delete ingress -n foxtrot -l app=foxtrot,dev=$(DEV)
+
 deployment/%:
 	mkdir $@
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint-with-docker:  ## Lint source code with docker image of golangci-lint
 .PHONY: lint lint-with-local lint-with-docker
 
 # --- Docker -------------------------------------------------------------------
-DOCKER_TAG ?= $(error DOCKER_TAG not set)
+DOCKER_TAG ?= $(or $(DEV),$(error DOCKER_TAG not set))
 DOCKER_TAGS = $(DOCKER_TAG) $(if $(filter true,$(DOCKER_PUSH_LATEST)),latest)
 DOCKER_BUILD_ARGS = \
 	--build-arg=SEMVER=$(SEMVER) \

--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -3,17 +3,19 @@
     hostname: null,
     docker_tag: 'latest',
     dev: '',
+    commit_sha: '',
 
     // derived
     nameSuffix: if self.dev != '' then '-' + self.dev else '',
     hostPrefix: if self.dev != '' then self.dev + '.' else '',
   },
-  configure(overlay={}, hostname=null, docker_tag=null, dev=null)::
+  configure(overlay={}, hostname=null, docker_tag=null, dev=null, commit_sha=null)::
     self + overlay + {
       config+: std.prune({
         hostname: hostname,
         docker_tag: docker_tag,
         dev: dev,
+        commit_sha: commit_sha,
       }),
     },
 
@@ -72,6 +74,9 @@
           labels: {
             app: 'foxtrot',
             dev: $.config.dev,
+          },
+          annotations: {
+            commit_sha: $.config.commit_sha,
           },
         },
         spec: {

--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -5,8 +5,8 @@
     dev: '',
 
     // derived
-    nameSuffix: if self.dev != null then '-' + self.dev else '',
-    hostPrefix: if self.dev != null then self.dev + '.' else '',
+    nameSuffix: if self.dev != '' then '-' + self.dev else '',
+    hostPrefix: if self.dev != '' then self.dev + '.' else '',
   },
   configure(overlay={}, hostname=null, docker_tag=null, dev=null)::
     self + overlay + {


### PR DESCRIPTION
Annotate deployment template spec with commit sha so that a pod is
re-deployed if nothing in deployment has changed.

Replace $(REF) with $(COMMIT_SHA) for consistency