### PR TITLE
deploy: Undeploy per-PR deployments when closed

### DIFF
--- a/.github/workflows/undeploy.yaml
+++ b/.github/workflows/undeploy.yaml
@@ -1,0 +1,18 @@
+name: Undeploy PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  undeploy:
+    name: Undeploy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: make jcdc-undeploy-goat
+      env:
+        COMMIT_SHA: ${{ github.sha }}
+        DEV: pr${{ github.event.number }}
+        JCDC_URL: https://jcdc.jul.run/run
+        JCDC_API_KEY: ${{ secrets.GOAT_JCDC_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,6 @@ diff-deploy-%: ## Show diff of k8s manifests between files and deployed
 undeploy-%:  ## Delete deployment
 	kubecfg delete $(TLA_ARGS) deployment/main.jsonnet
 
-dev-undeploy-%:  ## Delete dev deployment
-	kubectl delete all -n foxtrot -l app=foxtrot,dev=$(DEV)
-	kubectl delete ingress -n foxtrot -l app=foxtrot,dev=$(DEV)
-
 deployment/%:
 	mkdir $@
 

--- a/deployment/foxtrot.jsonnet
+++ b/deployment/foxtrot.jsonnet
@@ -20,7 +20,7 @@
     },
 
   manifest: [
-    $.namespace,
+    if $.config.dev == '' then $.namespace,
     $.service,
     $.deployment,
     if $.config.hostname != null then $.ingress,

--- a/deployment/goat/overlay.jsonnet
+++ b/deployment/goat/overlay.jsonnet
@@ -1,5 +1,5 @@
 {
-  manifest+: [$.sealedSecret],
+  manifest+: [if self.config.dev == '' then $.sealedSecret],
   config+: {
     hostname: 'foxtrot.jul.run',
   },


### PR DESCRIPTION
Fix the deployment and add a workflow to make undeploying a per-PR deployment
work. While we're here, deduplicate some of the logic in the Makefile around
local/remote deployments.