### PR TITLE
ci: Update go version to 1.16.0-rc1

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,10 +11,9 @@ jobs:
     name: Backend CI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1
       with:
-        stable: false
-        go-version: 1.16.0-rc1
+        go-version: 1.16rc1
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         stable: false
-        go-version: 1.16.0-beta1
+        go-version: 1.16.0-rc1
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0


### PR DESCRIPTION
Update the Go version to 1.16.0-rc1 from 1.16.0-beta1. The latter is no
longer available now that the rc has been released.