### PR TITLE
make: Pin golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,22 +55,20 @@ FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_
 # --- Lint ---------------------------------------------------------------------
 GOLINT_VERSION = 1.33.2
 GOLINT_INSTALLED_VERSION = $(or $(word 4,$(shell golangci-lint --version 2>/dev/null)),0.0.0)
-GOLINT_MIN_VERSION = $(shell printf '%s\n' $(GOLINT_VERSION) $(GOLINT_INSTALLED_VERSION) | sort -V | head -n 1)
-GOPATH1 = $(firstword $(subst :, ,$(GOPATH)))
-LINT_TARGET = $(if $(filter $(GOLINT_MIN_VERSION),$(GOLINT_VERSION)),lint-with-local,lint-with-docker)
+GOLINT_USE_INSTALLED = $(filter $(GOLINT_INSTALLED_VERSION),v$(GOLINT_VERSION) $(GOLINT_VERSION))
+GOLINT = $(if $(GOLINT_USE_INSTALLED),golangci-lint,golangci-lint-v$(GOLINT_VERSION))
 
-lint: $(LINT_TARGET)  ## Lint source code
+GOBIN ?= $(firstword $(subst :, ,$(GOPATH)))/bin
 
-lint-with-local:  ## Lint source code with locally installed golangci-lint
-	golangci-lint run
+lint: $(if $(GOLINT_USE_INSTALLED),,$(GOBIN)/$(GOLINT))  ## Lint go source code
+	$(GOLINT) run
 
-lint-with-docker:  ## Lint source code with docker image of golangci-lint
-	docker run --rm -w /src \
-		-v $(shell pwd):/src -v $(GOPATH1):/go -v $(HOME)/.cache:/root/.cache \
-		golangci/golangci-lint:v$(GOLINT_VERSION) \
-		golangci-lint run
+$(GOBIN)/$(GOLINT):
+	cd /tmp; \
+	GOBIN=/tmp GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v$(GOLINT_VERSION); \
+	mv /tmp/golangci-lint $@
 
-.PHONY: lint lint-with-local lint-with-docker
+.PHONY: lint
 
 # --- Docker -------------------------------------------------------------------
 DOCKER_TAG ?= $(or $(DEV),$(error DOCKER_TAG not set))


### PR DESCRIPTION
Pin golangci-lint version to exact given version number and don't just
ensure it is at or _above_ a minimum version number. We've had cases
where new golangci-lint versions listed errors that older ones didn't.

Rather than using docker use `go get` to install correct version as
{GOBIN}/golangci-lint-vX.Y.Z.

Thanks @camh- for doing all the work and letting me take credit.